### PR TITLE
Update check for if the directory  ${SHARED_DIR} exists

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,15 +25,17 @@ set -e
 # Include the user set variables
 source "${PWD}/properties.env"
 
-# shellcheck source=../gke-istio-shared/verify-functions.sh
-
-# Source utility functions for checking the existence of various resources.
-source "${SHARED_DIR}/verify-functions.sh"
-
 # Ensure that the directory containing all of the necessary scripts exists
-if ! directory_exists "${SHARED_DIR}" ; then
-  echo "${SHARED_DIR} does not exist, please check the variable "
-  echo "settings in the properties file."
+if [[ -d "${SHARED_DIR}" ]]; then
+  # shellcheck source=../gke-istio-shared/verify-functions.sh
+
+  # Source utility functions for checking the existence of various resources.
+  source "${SHARED_DIR}/verify-functions.sh"
+else
+  echo "${SHARED_DIR} does not exist, please check the variable settings in \
+the properties file."
+  echo "Also make sure you clone the shared repository located at: \
+https://github.com/GoogleCloudPlatform/gke-istio-shared"
   echo "Exiting..."
   exit 1
 fi


### PR DESCRIPTION
The ${SHARED_DIR} directory is being checked after we try to source it. I moved it so it will only be sourced if ${SHARED_DIR} exists.

I changed the way we check if ${SHARED_DIR} exists. We're calling the function directory_exists on the directory ${SHARED_DIR} but the code for that function is in ${SHARED_DIR}/verify-functions.sh. So if ${SHARED_DIR} does not exist neither does the function. 

Added messaging to clone the shared project 