### PR TITLE
Fixing up the automated testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,14 +69,16 @@ spec:
           sh "gcloud config set compute/zone ${env.ZONE}"
           sh "gcloud config set core/project ${env.PROJECT_ID}"
           sh "gcloud config set compute/region ${env.REGION}"
-         }
-    }
-    stage('Lint') {
-        container(containerName) {
+
           sh "sed -e \"s/<YOUR_PROJECT>/${env.PROJECT_ID}/g\" \
             -e \"s/<YOUR_ZONE>/${env.ZONE}/g\" \
             -e \"s/<YOUR_REGION>/${env.REGION}/g\" \
             properties > properties.env"
+         }
+    }
+
+    stage('Lint') {
+        container(containerName) {
           sh "make lint"
       }
     }

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Do not set errexit- we want to attempt to teardown everything
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-# properties file
+
 # shellcheck source=properties.env
 source "${ROOT}/properties.env"
 


### PR DESCRIPTION
* In teardown, Don't exit for every error. otherwise we get dangling resources
* Moves the creation of the properties.env into the setup phase of jenkinsfile