### PR TITLE
Update Cloudshell link and instructions to include submodule

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -9,6 +9,8 @@
     * [Istio Data Plane](#istio-data-plane)
   * [BookInfo Sample Application](#bookinfo-sample-application)
   * [Putting it All Together](#putting-it-all-together)
+* [Run Demo using Cloud Shell](#run-demo-using-cloud-shell)
+* [Initialize GCP](#initialize-gcp)
 * [Deployment](#deployment)
 * [Validation](#validation)
 * [Tear Down](#tear-down)
@@ -95,6 +97,20 @@ In the diagram, note:
 * The environment is setup in the Kubernetes Engine default network.
 
 ![](./images/istio-gke-gce.png)
+
+## Run Demo using Cloud Shell
+
+Use the `--recursive` argument to download dependencies provided via a git submodule.
+
+```shell
+git submodule update --init --recursive
+```
+
+## Initialize GCP
+
+```console
+gcloud init
+```
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,13 @@ _NOTE: This section can be skipped if the cloud deployment is being performed wi
 
 Click the button below to open the demo in your Cloud Shell:
 
-[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fgke-istio-gce-demo&page=editor&tutorial=README.md)
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/gke-istio-gce-demo.git&amp;cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&amp;cloudshell_tutorial=README.md)
+
+Use the `--recursive` argument to download dependencies provided via a git submodule.
+
+```shell
+git submodule update --init --recursive
+```
 
 To prepare [gcloud](https://cloud.google.com/sdk/gcloud/) for use in Cloud Shell, execute the following command in the terminal at the bottom of the browser window you just opened:
 


### PR DESCRIPTION
1. Cloud shell link update.
2. Instructions to include sub module "istio-shared" when using Cloud Shell.
3. Update TOC